### PR TITLE
Feature/indexed matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Compares `mainString` against each string in `targetDocuments` that have ids. Th
 
 ##### Examples
 ```javascript
-stringSimilarity.findBestMatch('Olive-green table for sale, in extremely good condition.', [{ id: 1,
+stringSimilarity.findBestMatchWithIndex('Olive-green table for sale, in extremely good condition.', [{ id: 1,
   string: 'For sale: green Subaru Impreza, 210,000 miles'},
   {id: 2, string: 'For sale: table in very good condition, olive green in colour.'},
   {id: 3, string: 'Wanted: mountain bike with at least 21 gears.'}

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ In your code:
 ```javascript
 var stringSimilarity = require('string-similarity');
 
-var similarity = stringSimilarity.compareTwoStrings('healed', 'sealed'); 
+var similarity = stringSimilarity.compareTwoStrings('healed', 'sealed');
 
 var matches = stringSimilarity.findBestMatch('healed', ['edward', 'sealed', 'theatre']);
+
+var indexedMatches = stringSimilarity.findBestMatchWithIndex('healed', [{ id: 1, string: 'mailed' }, { id: 2, string: 'edward'}, { id: 3, string: 'sealed' }, { id: 4, string: 'theatre' } ])
+
 ```
 ## API
 
@@ -28,31 +31,31 @@ Requiring the module gives an object with two methods:
 Returns a fraction between 0 and 1, which indicates the degree of similarity between the two strings. 0 indicates completely different strings, 1 indicates identical strings. The comparison is case-insensitive.
 
 ##### Arguments
-  
+
 1. string1 (string): The first string
 2. string2 (string): The second string
-  
+
 Order does not make a difference.
-  
+
 ##### Returns
-  
+
 (number): A fraction from 0 to 1, both inclusive. Higher number indicates more similarity.
 
 ##### Examples
-  
+
 ```javascript
 stringSimilarity.compareTwoStrings('healed', 'sealed');
 // → 0.8
 
-stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.', 
+stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.',
   'For sale: table in very good  condition, olive green in colour.');
 // → 0.7073170731707317
 
-stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.', 
+stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.',
   'For sale: green Subaru Impreza, 210,000 miles');
 // → 0.3013698630136986
 
-stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.', 
+stringSimilarity.compareTwoStrings('Olive-green table for sale, in extremely good condition.',
   'Wanted: mountain bike with at least 21 gears.');
 // → 0.11267605633802817
 ```
@@ -72,11 +75,11 @@ Compares `mainString` against each string in `targetStrings`.
 ##### Examples
 ```javascript
 stringSimilarity.findBestMatch('Olive-green table for sale, in extremely good condition.', [
-  'For sale: green Subaru Impreza, 210,000 miles', 
-  'For sale: table in very good condition, olive green in colour.', 
+  'For sale: green Subaru Impreza, 210,000 miles',
+  'For sale: table in very good condition, olive green in colour.',
   'Wanted: mountain bike with at least 21 gears.'
 ]);
-// → 
+// →
 { ratings:
    [ { target: 'For sale: green Subaru Impreza, 210,000 miles',
        rating: 0.3013698630136986 },
@@ -88,6 +91,39 @@ stringSimilarity.findBestMatch('Olive-green table for sale, in extremely good co
    { target: 'For sale: table in very good condition, olive green in colour.',
      rating: 0.7073170731707317 } }
 ```
+
+### findBestMatchWithIndex(targetString, targetDocuments)
+
+Compares `mainString` against each string in `targetDocuments` that have ids. This is useful in instances where you might pre-process the strings and require to keep an id.
+
+##### Arguments
+
+1. mainString (string): The string to match each target string against.
+2. targetDocuments (Array): Each document in this array is an object with two keys (id, and string). The string property will be matched against the main string.
+
+##### Returns
+(Object): An object with a `ratings` property, which gives a similarity rating for each target string the id as passed in, and a `bestMatch` property, which specifies which target string was most similar to the main string.
+
+##### Examples
+```javascript
+stringSimilarity.findBestMatch('Olive-green table for sale, in extremely good condition.', [{ id: 1,
+  string: 'For sale: green Subaru Impreza, 210,000 miles'},
+  {id: 2, string: 'For sale: table in very good condition, olive green in colour.'},
+  {id: 3, string: 'Wanted: mountain bike with at least 21 gears.'}
+]);
+// →
+{ ratings:
+   [ { id: 1, target: 'For sale: green Subaru Impreza, 210,000 miles',
+       rating: 0.3013698630136986 },
+     { id: 2, target: 'For sale: table in very good condition, olive green in colour.',
+       rating: 0.7073170731707317 },
+     { id: 3, target: 'Wanted: mountain bike with at least 21 gears.',
+       rating: 0.11267605633802817 } ],
+  bestMatch:
+   { id: 2, target: 'For sale: table in very good condition, olive green in colour.',
+     rating: 0.7073170731707317 } }
+```
+
 
 ## Build Status		
 ![Build status](https://codeship.com/projects/2aa453d0-0959-0134-8a76-4abcb29fe9b4/status?branch=master)

--- a/compare-strings.js
+++ b/compare-strings.js
@@ -6,6 +6,7 @@ var _flattenDeep = require('lodash/flattenDeep');
 
 exports.compareTwoStrings = compareTwoStrings;
 exports.findBestMatch = findBestMatch;
+exports.findBestMatchWithIndex = findBestMatchWithIndex;
 
 function compareTwoStrings(str1, str2) {
   var result = null;
@@ -116,5 +117,37 @@ function findBestMatch(mainString, targetStrings) {
       });
 
     return mainStringIsAString && targetStringsIsAnArrayOfStrings;
+  }
+}
+
+function findBestMatchWithIndex(mainString, targetDocuments) {
+  if (!areArgsValid(mainString, targetDocuments)) {
+    throw new Error('Bad arguments: First argument should be a string, second should be an array of documents');
+  }
+
+  var ratings = _map(targetDocuments, function (doc) {
+    return {
+      id: doc.id,
+      target: doc.string,
+      rating: compareTwoStrings(mainString, doc.string)
+    };
+  });
+
+  return {
+    ratings: ratings,
+    bestMatch: _maxBy(ratings, 'rating')
+  };
+
+  // private functions ---------------------------
+  function areArgsValid(mainString, targetDocuments) {
+    var mainStringIsAString = (typeof mainString === 'string');
+
+    var targetStringsIsAnArrayOfDocuments = Array.isArray(targetDocuments) &&
+      targetDocuments.length > 0 &&
+      _every(targetDocuments, function (doc) {
+        return (typeof doc === 'object' && doc.id && doc.string);
+      });
+
+    return mainStringIsAString && targetStringsIsAnArrayOfDocuments;
   }
 }

--- a/compare-strings.spec.js
+++ b/compare-strings.spec.js
@@ -9,7 +9,7 @@ describe('compareTwoStrings', function () {
 
   it('returns the correct value for different inputs:', function () {
     const testData = [
-      {first: 'french', second: 'quebec', expected: 0},  
+      {first: 'french', second: 'quebec', expected: 0},
       {first: 'france', second: 'france', expected: 1},
       {first: 'fRaNce', second: 'france', expected: 1},
       {first: 'healed', second: 'sealed', expected: 0.8},
@@ -21,7 +21,7 @@ describe('compareTwoStrings', function () {
       {first: '', second: '', expected: 1},
       {first: 'a', second: '', expected: 0},
       {first: '', second: 'a', expected: 0}
-    ];   
+    ];
 
     testData.forEach(td => {
       expect(compareTwoStrings(td.first, td.second)).toEqual(td.expected);
@@ -91,3 +91,66 @@ describe('findBestMatch', function () {
     expect(matches.bestMatch).toEqual({target: 'sealed', rating: 0.8});
   });
 });
+
+describe('findBestMatchWithIndex', function() {
+  var findBestMatchWithIndex = stringSimilarity.findBestMatchWithIndex;
+  var badArgsErrorMsg = 'Bad arguments: First argument should be a string, second should be an array of documents';
+
+  it('is a function', function () {
+    expect(typeof findBestMatchWithIndex).toBe('function');
+  });
+
+  it('accepts a string and an array of strings and returns an object', function () {
+    var output = findBestMatchWithIndex('one', [{ id: '1', string: 'one'}, { id: '2', string: 'two'}]);
+    expect(typeof output).toBe('object');
+  });
+
+  it("throws a 'Bad arguments' error if no arguments passed", function () {
+    expect(function () {
+      findBestMatchWithIndex();
+    }).toThrowError(badArgsErrorMsg);
+  });
+
+  it("throws a 'Bad arguments' error if first argument is not a non-empty string", function () {
+    expect(function () {
+      findBestMatchWithIndex('');
+    }).toThrowError(badArgsErrorMsg);
+
+    expect(function () {
+      findBestMatchWithIndex(8);
+    }).toThrowError(badArgsErrorMsg);
+  });
+
+  it("throws a 'Bad arguments' error if second argument is not an array with at least one element", function () {
+    expect(function () {
+      findBestMatchWithIndex('hello', 'something');
+    }).toThrowError(badArgsErrorMsg);
+
+    expect(function () {
+      findBestMatchWithIndex('hello', []);
+    }).toThrowError(badArgsErrorMsg);
+  });
+
+  it("throws a 'Bad arguments' error if second argument is not an array of documents", function () {
+    expect(function () {
+      findBestMatchWithIndex('hello', ['sdfdsf', 'something']);
+    }).toThrowError(badArgsErrorMsg);
+  });
+
+  it('assigns a similarity rating to each string passed in the array', function () {
+    var matches = findBestMatchWithIndex('healed', [{ id: 1, string: 'mailed' }, { id: 2, string: 'edward'} , { id: 3, string: 'sealed' }, { id: 4, string: 'theatre' } ]);
+
+    expect(matches.ratings).toEqual([
+      {id: 1, target: 'mailed', rating: 0.4},
+      {id: 2, target: 'edward', rating: 0.2},
+      {id: 3, target: 'sealed', rating: 0.8},
+      {id: 4, target: 'theatre', rating: 0.36363636363636365}
+    ]);
+  });
+
+  it("returns the best match and it's similarity rating", function () {
+    var matches = findBestMatchWithIndex('healed', [{ id: 1, string: 'mailed' }, { id: 2, string: 'edward'} , { id: 3, string: 'sealed' }, { id: 4, string: 'theatre' } ]);
+
+    expect(matches.bestMatch).toEqual({id: 3, target: 'sealed', rating: 0.8});
+  });
+})


### PR DESCRIPTION
This PR checks in:

- Ability to provide ids for the strings on which the search is performed.

This is useful in the instance where you might perform some modifications on your search strings but would like to be able to retrieve the original text from the ratings results. E.g. Assume you are comparing tweets for similarity but would like to exclude all handles.

Example:
`
var stringSimilarity = require('string-similarity')
var tweets = [{ id: 1, string: "Hi @twitter how are you" }, {id: 2, string: "Bye @twitter goodbye" }]

// removes handles e.g. "Hi @twitter" will return "Hi "
function removeHandles(text) {
  return text.replace(/@+(\w){1,30}/g, '')
}


var processedDocs = tweets.map(function(it) { return { id: it.id, string: removeHandles(it.string) })
var search = removeHandles("Bye @facebook goodbye");


var ratings = stringSimilarity.findBestMatchWithIndex(search, processedDocs);
var best = ratings.bestMatch;

// now you can get the original tweet from this id
var originalTweet = tweets.find(function(tweet) { return tweet.id == best.id });