### PR TITLE
Use Array.some instead of Array.find

### DIFF
--- a/compare-strings.js
+++ b/compare-strings.js
@@ -39,7 +39,7 @@ function areArgsValid (mainString, targetStrings) {
 	if (typeof mainString !== 'string') return false;
 	if (!Array.isArray(targetStrings)) return false;
 	if (!targetStrings.length) return false;
-	if (targetStrings.find(s => typeof s !== 'string')) return false;
+	if (targetStrings.some(s => typeof s !== 'string')) return false;
 	return true;
 }
 


### PR DESCRIPTION
Array.find will return the item that passes the filter, rather than a Boolean of whether an item passed the filter. So if any falsy item is in the array (e.g. `null`, `NaN`, etc.), the if statement will not return false.